### PR TITLE
Fixed an issue while requests hang when urls to block are not present

### DIFF
--- a/src/RequestInterceptor.ts
+++ b/src/RequestInterceptor.ts
@@ -116,6 +116,7 @@ export class RequestInterceptor {
                 this.logger.log((<Error> error).toString());
             }
         } else {
+            await interceptedUrl.continue();
             this.logger.log(`loaded: ${url}`);
         }
     }


### PR DESCRIPTION
So in general I'm using it only for faking the responses and reading from the code it seems that it will not continue the request if there're no urls to block added. I didn't had a chance to test this change properly, but with faking feature it works perfectly fine and fixes my issue.

Great work done with this extension, thanks and cheers 🎉.
Happy to help and contribute.